### PR TITLE
Removing article link "This topic is no longer available"

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@
 <div style="text-align: center;">&nbsp;</div>
 <div style="text-align: center;"><img id="143452" src="https://i1.code.msdn.s-msft.com/windowsapps/service-bus-explorer-f2abca5a/image/file/143452/1/servicebusexplorer.jpg" alt="" /></div>
 <div></div>
-<div>Read the full article on <a title="MSDN" href="http://msdn.microsoft.com/en-us/library/hh532261(v=VS.103).aspx" target="_blank"> MSDN</a>.</div>
 <div><strong>NOTE</strong>: I'll continue to develop the tool and add new functionalities. So I strongly recommend you to visit this page from time to time for a new version.</div>
 <div><strong>Author: </strong>Paolo Salvatori</div>
 <div><strong>Update</strong>: 28 August 2012</div>


### PR DESCRIPTION
<div>Read the full article on <a title="MSDN" href="http://msdn.microsoft.com/en-us/library/hh532261(v=VS.103).aspx" target="_blank"> MSDN</a>.</div>


_This link is broken:_ http://msdn.microsoft.com/en-us/library/hh532261(v=VS.103).aspx
Not sure of the correct link to replace it with, and/or if instead it should be omitted altogether as it may no longer be relevant?

Also as I understand it the Windows Azure Management Portal is now referred to either as the "classic" portal: https://manage.windowsazure.com or the "new" portal: https://portal.azure.com/ but didn't want to change any URLs. Does the Service Bus Explorer interacts in different ways depending on which portal and their different functionalities?
